### PR TITLE
rewrite references to other soy templates as require calls

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -32,14 +32,15 @@ module.exports = function (grunt) {
     },
 
     // Configuration to be run (and then tested).
-    soy_to_require: {
+    'soy-to-require': {
       TestTask: {
         options: {
           namespace: 'Testing',
+          prefix: 'abc',
           output: 'tmp/'
         },
         files: {
-          'test/fixtures': ['test/fixtures/MyView.soy.js', 'test/fixtures/MyView.soy.js']
+          'test/fixtures': ['test/fixtures/MyView.soy.js','test/fixtures/UsesView.soy.js']
         }
       }
     },
@@ -56,7 +57,7 @@ module.exports = function (grunt) {
 
   // Whenever the "test" task is run, first clean the "tmp" dir, then run this
   // plugin's task(s), then test the result.
-  grunt.registerTask('test', ['clean', 'soy_to_require', 'nodeunit']);
+  grunt.registerTask('test', ['clean', 'soy-to-require', 'nodeunit']);
 
   // By default, lint and run all tests.
   grunt.registerTask('default', ['jshint', 'test']);

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Type: `String`
 
 Default value: `null`
 
-A string value that is used to do something with whatever.
+The Soy namespace.
 
 #### options.output
 Type: `String`
@@ -53,6 +53,14 @@ Default value: `{input_file_path}`
 
 Allows you to override the output directory,
 
+#### options.prefix
+Type: `String`
+
+Default value: ""
+
+The prefix used for resolving other Soy modules. This gets appended to
+`options.output` to form the location of the AMD module.
+
 ### Usage Examples
 In this example, the default options are used to do something with whatever. So if the `testing` file has the content `Testing` and the `123` file had the content `1 2 3`, the generated result would be `Testing, 1 2 3.`
 
@@ -62,7 +70,8 @@ grunt.initConfig({
       TestTask: {
         options: {
             namespace: 'Testing',
-            output: 'templates/'
+            prefix: 'templates/',
+            output: 'dist/js'
         },
         files: {
           'test/fixtures': ['templates/MyView.soy.js', 'test/fixtures/MyView.soy.js']

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "soy-to-require",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Wrap your closure templates in a require js define block",
   "homepage": "https://github.com/charliedowler/soy-to-require",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
   "license": "MIT",
   "dependencies": {
     "colors": "0.6.2",
-    "node-js-beautify": "0.1.0"
+    "falafel": "^1.1.0",
+    "node-js-beautify": "0.1.0",
+    "underscore": "^1.8.3"
   },
   "devDependencies": {
     "grunt-contrib-clean": "~0.5.0",

--- a/tasks/soy_to_require.js
+++ b/tasks/soy_to_require.js
@@ -13,21 +13,22 @@ module.exports = function (grunt) {
   // Please see the Grunt documentation for more information regarding task
   // creation: http://gruntjs.com/creating-tasks
 
-  grunt.registerMultiTask('soy_to_require', 'desc', function () {
+  grunt.registerMultiTask('soy-to-require', 'desc', function () {
     var Beautifier = require('node-js-beautify');
+    var falafel = require('falafel');
     var formatter = new Beautifier();
     var path = require('path');
+    var _ = require('underscore');
     require('colors');
 
     var options = this.options();
     var namespace = options.namespace;
-    var output = options.output;
-    var count = 0;
+    var prefix = options.prefix || '';
+    var output = path.join(options.output, prefix);
 
     // Iterate over all specified file groups.
-    this.files.forEach(function (file) {
-      // Concat specified files.
-      var src = file.src.filter(function (filepath) {
+    var src = _(this.files.map(function(file) {
+      return file.src.filter(function (filepath) {
         // Warn on and remove invalid source files (if nonull was set).
         if (!grunt.file.exists(filepath)) {
           grunt.log.warn('Source file "' + filepath + '" not found.');
@@ -40,22 +41,62 @@ module.exports = function (grunt) {
           path: filepath,
           contents: grunt.file.read(filepath)
         };
-      }).forEach(function(file, index, list) {
-        var filename = path.basename(file.path);
-        var wrapper = ['define(function(require) {'
-          , 'var soy = require("soy");'
-          , file.contents
-          , 'return ' + namespace + '.' + filename.split('.')[0] + ';'
-          , '});'].join('\n');
-        wrapper = formatter.beautify_js(wrapper, {
-          'indent_size': 2
-        });
-        grunt.file.write([output + filename].join('.'), wrapper);
-        grunt.log.writeln('File "' + [output + filename].join('.') + '" created.');
-        count++;
       });
-    });
-    grunt.log.writeln('Successfully generated ' + count.toString().cyan + ' templates.');
-  });
+    })).flatten();
 
+    // Concat specified files.
+    src.forEach(function(file) {
+      var filename = path.basename(file.path);
+      var module = filename.split('.')[0];
+      var dependencies = {
+        soy: 'soy'
+      };
+
+      var code = falafel(file.contents, function(node) {
+        var dependency = isSoyMemberExpression(node);
+        if (dependency) {
+          node.update(varName(dependency));
+        }
+      });
+
+      var prologue = 'define(function(require) {';
+      var epilogue = 'return ' + namespace + '.' + module + '; });';
+      var requires = _.map(dependencies, function(v,k) {
+        return 'var ' + v + ' = require("' + k + '");';
+      });
+
+      var wrapper = formatter.beautify_js([].concat(prologue, requires, code, epilogue).join('\n'), { 'indent_size': 2 });
+
+      var destFile = path.join(output, filename);
+      grunt.file.write(destFile, wrapper);
+      grunt.log.writeln('File "' + destFile + '" created.');
+
+      /**
+       * @return [String] the module to require if the node is a call to another Soy module within our namespace, undefined otherwise
+       */
+      function isSoyMemberExpression(node) {
+        if (node.type === 'MemberExpression' && node.object.name === namespace && node.property.name !== module && node.computed === false) {
+          return node.property.name + '.soy';
+        }
+      }
+
+      /**
+       * @return String a unique variable name used for the given module name
+       */
+      function varName(module) {
+        var name = module.split('.')[0];
+        var path = prefix + '/' + module;
+
+        if (!dependencies[path]) {
+          dependencies[path] = name;
+        }
+
+        return dependencies[path];
+      }
+    });
+
+    grunt.log.writeln('Successfully generated ' + src.length.toString().cyan + ' templates.');
+  });
 };
+
+

--- a/test/expected/UsesView.soy.js
+++ b/test/expected/UsesView.soy.js
@@ -1,0 +1,16 @@
+define(function(require) {
+  var soy = require("soy");
+  var MyView = require("abc/MyView.soy");
+  if (typeof Testing == 'undefined') {
+    var Testing = {};
+  }
+
+  Testing.UsesView.hello = function(opt_data, opt_ignored) {
+    var output = new soy.StringBuilder();
+    MyView(opt_data, output);
+    output.append('<div>Hello World</div>');
+    return output;
+  };
+
+  return Testing.UsesView;
+});

--- a/test/fixtures/UsesView.soy.js
+++ b/test/fixtures/UsesView.soy.js
@@ -1,0 +1,10 @@
+if (typeof Testing == 'undefined') {
+  var Testing = {};
+}
+
+Testing.UsesView.hello = function (opt_data, opt_ignored) {
+  var output = new soy.StringBuilder();
+  Testing.MyView(opt_data, output);
+  output.append('<div>Hello World</div>');
+  return output;
+};

--- a/test/soy_to_require_test.js
+++ b/test/soy_to_require_test.js
@@ -24,10 +24,16 @@ var grunt = require('grunt');
 
 exports.soy_to_require = {
   TestTask: function (test) {
+    var files = [
+      [ 'tmp/abc/MyView.soy.js',   'test/expected/MyView.soy.js' ],
+      [ 'tmp/abc/UsesView.soy.js', 'test/expected/UsesView.soy.js' ]
+    ];
 
-    var actual = grunt.file.read('tmp/MyView.soy.js');
-    var expected = grunt.file.read('test/expected/MyView.soy.js');
-    test.equal(actual, expected, 'should describe what the default behavior is.');
+    files.forEach(function(file) {
+      var actual = grunt.file.read(file[0]);
+      var expected = grunt.file.read(file[1]);
+      test.equal(actual, expected, file[0] + ' differs from ' + file[1]);
+    });
 
     test.done();
   }


### PR DESCRIPTION
I've pulled in the falafel library to rewrite references to other templates as `require` calls. This makes it possible to reuse templates across several files (added `UsesView.soy.js` to test this).

Also introduced `options.prefix` for the prefix used on the AMD modules (this is needed to be able to resolve the other modules).
